### PR TITLE
Support true global monkey patching

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pytest-frozen-uuids
-version = 0.1
-description = Deterministically generated UUID's for your tests
+version = 0.2
+description = Deterministically frozen UUID's for your tests
 long_description = file:README.md
 long_description_content_type = text/markdown
 author = Simon Wahlgren


### PR DESCRIPTION
## Background

Currently, the fixture have to be called before any UUID imports in the application. This makes it very brittle, and enforces the application to be structured in a specific way for the tests to work.

This PR introduces "true" global monkey patching, what this means is that already imported UUID objects will also be patched (both globals and locals).