### PR TITLE
(fix) insert fixture last

### DIFF
--- a/pytest_frozen_uuids/__main__.py
+++ b/pytest_frozen_uuids/__main__.py
@@ -80,7 +80,7 @@ def pytest_collection_modifyitems(items):
     """Inject our fixture into any tests with our marker"""
     for item in items:
         if utils.get_closest_marker(item, MARKER_NAME):
-            item.fixturenames.insert(0, FIXTURE_NAME)
+            item.fixturenames.insert(len(item.fixturenames), FIXTURE_NAME)
 
 
 def pytest_configure(config):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-frozen-uuids
-version = 0.3.3
+version = 0.3.4
 description = Deterministically frozen UUID's for your tests
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Changes
 - Currently, we insert this fixture before all other fixtures. This will not work correctly in applications where we lazily import the application in eg. a factory function. For this fixture to work, we must make sure the application is fully imported before we monkey patch the imports. This fix will insert the fixture last, hopefully making sure the application is fully imported at the time the fixture runs.