### PR TITLE
Use packaging.Version instead of LooseVersion

### DIFF
--- a/pytest_frozen_uuids/utils.py
+++ b/pytest_frozen_uuids/utils.py
@@ -1,8 +1,8 @@
 import sys
 from typing import Iterator, Optional
-from packaging.version import Version
 
 import pytest
+from packaging.version import Version
 
 
 def get_closest_marker(node, name):

--- a/pytest_frozen_uuids/utils.py
+++ b/pytest_frozen_uuids/utils.py
@@ -1,6 +1,6 @@
 import sys
-from packaging.version import Version
 from typing import Iterator, Optional
+from packaging.version import Version
 
 import pytest
 

--- a/pytest_frozen_uuids/utils.py
+++ b/pytest_frozen_uuids/utils.py
@@ -1,5 +1,5 @@
 import sys
-from distutils.version import LooseVersion
+from packaging.version import Version
 from typing import Iterator, Optional
 
 import pytest
@@ -7,7 +7,7 @@ import pytest
 
 def get_closest_marker(node, name):
     """Get our marker, regardless of pytest version"""
-    if LooseVersion(pytest.__version__) < LooseVersion("3.6.0"):
+    if Version(pytest.__version__) < Version("3.6.0"):
         return node.get_marker(name)
     else:
         return node.get_closest_marker(name)


### PR DESCRIPTION
I noticed that there is a DeprecationWarning when I run our tests with the frozen-uuids:

> DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.

This is because of the deprecated LooseVersion. I changed that to use packaging.version.Version.

I ran linting and the tests successfully.

